### PR TITLE
Cache 機能の追加

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -84,9 +84,9 @@ impl AccessToken {
     // Save AccessToken Cache
     pub fn save_cache(&self, profile: &str) -> AccessToken {
         // open cache file
-        let path = AccessToken::cache_file(profile);
-        info!("{:?}", path.as_path());
-        let mut cache_file = File::create(path).unwrap();
+        // let path = AccessToken::cache_file(profile);
+        // info!("{:?}", path.as_path());
+        // let mut cache_file = File::create(path).unwrap();
 
         todo!()
     }

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -272,17 +272,17 @@ mod test {
             scope: Some("root".to_string()),
             ttl: None,
         };
-        token.save_cache("test_get_valid_cache").unwrap();
-        thread::sleep(Duration::from_secs(2));
+        token.save_cache("test_get_expired_cache").unwrap();
+        thread::sleep(Duration::from_secs(5));
 
         // exercise
-        let cache = AccessToken::load_cache("test_get_valid_cache");
+        let cache = AccessToken::load_cache("test_get_expired_cache");
 
         // verify
         assert_eq!(true, cache.is_none());
 
         // clean
-        AccessToken::remove_cache("test_get_valid_cache")
+        AccessToken::remove_cache("test_get_expired_cache")
     }
 }
 

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -95,7 +95,7 @@ impl AccessToken {
 
                 match serde_json::from_reader::<BufReader<File>, AccessToken>(reader) {
                     // ttl 取得失敗したら 0 とする
-                    Ok(t) if t.ttl.unwrap_or_else(|| u64::MIN) > now.as_secs() => {
+                    Ok(t) if t.ttl.unwrap_or(u64::MIN) > now.as_secs() => {
                         debug!("cache is valid. use cache!");
                         Some(t)
                     }

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -80,7 +80,12 @@ pub struct AccessToken {
 }
 
 impl AccessToken {
-    // Save AccessToken Cache
+    // Load AccessToken from Cache
+    pub fn load_cache(profile: &str) -> Option<AccessToken> {
+        None
+    }
+
+    // Save AccessToken in Cache
     pub fn save_cache(&self, profile: &str) -> AccessToken {
         // open cache file
         // let path = AccessToken::cache_file(profile);
@@ -92,7 +97,8 @@ impl AccessToken {
 
     // calculate ttl with expires_in in AccessToken
     fn calc_ttl(expires_in: u64) -> u64 {
-        // Epoch Sec に expires_in を加えた秒を TTL
+        // http://openid-foundation-japan.github.io/rfc6749.ja.html#token-response
+        // ttl = Epoch Sec + expires_in
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap();
@@ -233,10 +239,7 @@ impl GrantType {
         }
         .send()
         .await?;
-        res.json()
-            .await
-            // TODO: save cache here
-            .map_err(AccessTokenError::HttpError)
+        res.json().await.map_err(AccessTokenError::HttpError)
     }
 }
 

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -118,9 +118,10 @@ impl AccessToken {
         info!("{:?}", path.as_path());
         let mut cache_file = File::create(path).unwrap();
 
-        // Calculate TTL
-        self.ttl = Some(AccessToken::calc_ttl(self.expires_in));
-
+        // Calculate TTL, if ttl is None
+        if self.ttl.is_none() {
+            self.ttl = Some(AccessToken::calc_ttl(self.expires_in));
+        }
         // save json string
         let str = serde_json::to_string(&self).unwrap();
         debug!("Deserialize AccessToken {:?}", str);

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-use log::{debug, error};
+use log::{debug, error, info};
 use reqwest::header::{HeaderMap, CONTENT_TYPE, USER_AGENT};
 use reqwest::redirect::Policy;
 use reqwest::{Client, Response, StatusCode};
@@ -86,6 +86,7 @@ impl Dispatcher {
                     .await
                     .map_err(RequestError::OAuth)?,
             };
+            debug!("Get Token: {:?}", token);
 
             // save cache with AccessToken
             token.save_cache(&opts.profile);

--- a/src/request.rs
+++ b/src/request.rs
@@ -102,7 +102,9 @@ impl Dispatcher {
             debug!("{:?}", res);
             match res {
                 Ok(ok) => return Ok(ok),
-                Err(e) if e.status().map_or(false, |s| s == StatusCode::UNAUTHORIZED) => (),
+                Err(e) if e.status().map_or(false, |s| s == StatusCode::UNAUTHORIZED) => {
+                    AccessToken::remove_cache(&opts.profile)
+                }
                 Err(e) => return Err(RequestError::Http(e)),
             }
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -78,7 +78,7 @@ impl Dispatcher {
 
         loop {
             // test load cache from profile
-            let token = match AccessToken::load_cache("") {
+            let token = match AccessToken::load_cache(&opts.profile) {
                 Some(t) => t,
                 None => oauth2
                     .grant_type
@@ -88,7 +88,7 @@ impl Dispatcher {
             };
 
             // save cache with AccessToken
-            token.save_cache("");
+            token.save_cache(&opts.profile);
             let req = self
                 .client
                 .request(opts.request.clone(), opts.url.clone())

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-use log::{debug, error, info};
+use log::{debug, error, warn};
 use reqwest::header::{HeaderMap, CONTENT_TYPE, USER_AGENT};
 use reqwest::redirect::Policy;
 use reqwest::{Client, Response, StatusCode};
@@ -78,7 +78,7 @@ impl Dispatcher {
 
         loop {
             // test load cache from profile
-            let token = match AccessToken::load_cache(&opts.profile) {
+            let mut token = match AccessToken::load_cache(&opts.profile) {
                 Some(t) => t,
                 None => oauth2
                     .grant_type
@@ -89,7 +89,9 @@ impl Dispatcher {
             debug!("Get Token: {:?}", token);
 
             // save cache with AccessToken
-            token.save_cache(&opts.profile);
+            token
+                .save_cache(&opts.profile)
+                .unwrap_or_else(|err| warn!("can not save cache. {:?}", err));
             let req = self
                 .client
                 .request(opts.request.clone(), opts.url.clone())


### PR DESCRIPTION
# 概要

AccessToken の Cache を管理する機能を追加。

# 処理内容

1. 指定した Profile から Cache を検索
2. Cache から AccessToken を復元
3. Cache が存在しない、もしくは TTL が無効の場合は認可フローへ
4. 認可フローで、AccessToken を取得
5. AccessToken を Cache に保存
6. AccessToken を利用して、ターゲットへ接続

# 内容

- AccessToken に Cache 機能を追加
- Cache が存在したら読み込んで、AccessToken を復元する機能を追加