### PR TITLE
Add Build target matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,8 +13,14 @@ jobs:
       matrix:
         target:
           - x86_64-apple-darwin
+          - x86_64-pc-windows-gnu
+          - aarch64-apple-darwin
         include:
           - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
             os: macos-latest
 
     runs-on: ${{ matrix.os }}
@@ -68,8 +74,14 @@ jobs:
       matrix:
         target:
           - x86_64-apple-darwin
+          - x86_64-pc-windows-gnu
+          - aarch64-apple-darwin
         include:
           - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
             os: macos-latest
 
     needs: [create-release]


### PR DESCRIPTION
# 概要

Build Architecture  の追加。ひとまずなんとなく需要がありそうなやつらから。

# 内容

- feat: Add windows x64 Architecture (x86_64-pc-windows-gnu)
- feat: Add apple m1 Architecture (aarch64-apple-darwin)