### PR TITLE
Update reqwest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "07bea77bc708afa10e59905c3d4af7c8fd43c9214251673095ff8b14345fcbc5"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -1454,8 +1454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/cm-kazup0n/aurl-rust"
 
 [dependencies]
 
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.11.7", features = ["json"] }
 tokio = { version = "1.9.0", features = ["full"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.66"


### PR DESCRIPTION
# 概要

`rustup update` 実行後、リリースビルドにおいて `reqwest` のビルドが失敗するようになった。
reqwest の Version を Update して回避。

```bash
$ cargo build --release
   Compiling reqwest v0.11.4
error: expected one of `!` or `::`, found `#`
 --> /YOUR_HOME/.cargo/registry/src/github.com-1ecc6299db9ec823/reqwest-0.11.4/src/lib.rs:1:2
  |
1 | f#![deny(missing_docs)]
  |  ^ expected one of `!` or `::`

error: could not compile `reqwest` due to previous error
```

# 修正内容

- fix: v0.11.4 -> v0.11.7