### PR TITLE
Add request Timeout

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use log::{debug, info, warn};
 use rand::Rng;
@@ -369,6 +369,7 @@ impl GrantType {
     pub async fn get_access_token(
         &self,
         config: &OAuth2Config,
+        timeout: u64,
         http: &Client,
     ) -> Result<AccessToken, AccessTokenError> {
         let res = match self {
@@ -455,6 +456,7 @@ impl GrantType {
                     ])
             }
         }
+        .timeout(Duration::from_secs(timeout))
         .send()
         .await?;
         res.json().await.map_err(AccessTokenError::HttpError)

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,6 +20,8 @@ pub struct Opts {
     /// Output Option (case insensitive). curl: Output curl command snippet. none: Call URL with Got AccessToken.
     #[clap(long, default_value = "none")]
     pub output: Type,
+    #[clap(long, default_value = "30")]
+    pub timeout: u64,
     pub url: String,
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Display;
 use std::str::FromStr;
+use std::time::Duration;
 
 use log::{debug, error, warn};
 use reqwest::header::{HeaderMap, CONTENT_TYPE, USER_AGENT};
@@ -95,7 +96,7 @@ impl Dispatcher {
                 Some(t) => t,
                 None => oauth2
                     .grant_type
-                    .get_access_token(oauth2, &self.client)
+                    .get_access_token(oauth2, opts.timeout, &self.client)
                     .await
                     .map_err(RequestError::OAuth)?,
             };
@@ -130,6 +131,9 @@ impl Dispatcher {
                 debug!("non option. use bearer");
                 req.bearer_auth(token.access_token)
             };
+
+            // set timeout
+            let req = req.timeout(Duration::from_secs(opts.timeout));
 
             debug!("{:?}", req);
             // output 指定があったら send 実行せずに return


### PR DESCRIPTION
# 概要

Timeout オプションを追加した。アクセストークン取得時のRequestと指定URLへのRequestそれぞれ同じ値がセットされる。

- デフォルト30秒
-  u64 で型を指定

# 修正内容

- feat: アクセストークン取得Requestに Timeout 設定
- feat: アクセストークン取得後、指定URLへのRequest に Timeout 設定