### PR TITLE
ローカルサーバーを一時的に立てて認可コードを自動的に処理できるコードを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "log",
  "log4rs",
  "rand",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,5 @@ webbrowser = "^0.6.0"
 base64 = "^0.13.0"
 sha2 = "^0.10.2"
 base64-url = "^1.4.13"
+regex = "1"
+

--- a/src/authserver.rs
+++ b/src/authserver.rs
@@ -1,0 +1,96 @@
+use log::{error, debug};
+use std::io::Write;
+use std::io::{self, BufRead};
+use std::net::TcpListener;
+
+mod path_util {
+    use clap::lazy_static::lazy_static;
+    use regex::Regex;
+
+    lazy_static! {
+        pub static ref PATH_REGEX: Regex = Regex::new(".*?code=(?P<code>.+)&").unwrap();
+    }
+}
+
+pub struct AuthCodeServer {
+    port: i32,
+}
+
+impl AuthCodeServer {
+    pub fn new(port: i32) -> AuthCodeServer {
+        AuthCodeServer { port }
+    }
+
+    pub fn receive_auth_code(self) -> Result<String, ()> {
+        let server = TcpListener::bind(format!("127.0.0.1:{}", self.port)).unwrap();
+        let mut auth_code_opt: Option<String> = None;
+        if let Some(stream) = server.incoming().next() {
+            match stream {
+                Ok(stream) => {
+                    let mut stream = io::BufReader::new(stream);
+                    let mut first_line = String::new();
+                    if let Err(error) = stream.read_line(&mut first_line) {
+                        error!("{}", error);
+                    }
+
+                    // スペースで分割
+                    let mut params = first_line.split_whitespace();
+                    let method = params.next();
+                    let path = params.next();
+                    let auth_code_result = match (method, path) {
+                        (Some("GET"), Some(path)) => {
+                            let stream = stream.get_mut();
+                            println!("path: {}", path);
+
+                            if let Some(code) = path_util::PATH_REGEX.captures(path) {
+                                let code = code.name("code").unwrap().as_str();
+
+                                // ブラウザに空レスポンス
+                                writeln!(stream, "HTTP/1.1 200 OK").unwrap();
+                                writeln!(stream, "Content-Type: text/plain; charset=UTF-8")
+                                    .unwrap();
+                                writeln!(stream, "{}", code).unwrap();
+                                Ok(code)
+                            } else {
+                                Err("failed capture auth_code")
+                            }
+                        }
+                        _ => Err("unknown Method"),
+                    };
+                    match auth_code_result {
+                        Ok(code) => auth_code_opt = Some(code.to_string()),
+                        Err(str) => error!("{}", str),
+                    }
+                }
+                Err(_) => {
+                    error!("Callback Server error");
+                }
+            }
+        }
+        match auth_code_opt {
+            Some(code) => {
+                debug!("get auth code: {}", code);
+                Ok(code)
+            },
+            None => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::path_util;
+
+    #[test]
+    fn test_regex_path() {
+        match path_util::PATH_REGEX
+            .captures("?hogehoge=fugafuga&code=ZZZZ-XXXX-CCCC&state=hogehoge")
+        {
+            Some(path) => {
+                let code = path.name("code").unwrap().as_str();
+                assert_eq!(code, "ZZZZ-XXXX-CCCC")
+            }
+            None => panic!("test failed"),
+        }
+    }
+}

--- a/src/authserver.rs
+++ b/src/authserver.rs
@@ -57,7 +57,7 @@ impl AuthCodeServer {
                             let stream = stream.get_mut();
                             writeln!(stream, "HTTP/1.1 200 OK").unwrap();
                             writeln!(stream, "Content-Type: text/plain; charset=UTF-8").unwrap();
-                            writeln!(stream, "auth_code={}", code.to_string()).unwrap();
+                            writeln!(stream, "auth_code={}", code).unwrap();
 
                             debug!("get auth code: {}", code);
                             return Ok(code.to_string());

--- a/src/authserver.rs
+++ b/src/authserver.rs
@@ -1,6 +1,6 @@
 use log::{error, debug};
-use std::io::Write;
 use std::io::{self, BufRead};
+use std::io::Write;
 use std::net::TcpListener;
 
 mod path_util {
@@ -9,6 +9,26 @@ mod path_util {
 
     lazy_static! {
         pub static ref PATH_REGEX: Regex = Regex::new(".*?code=(?P<code>.+)&").unwrap();
+    }
+
+    pub fn split_auth_code(first_line: &str) -> Result<&str, &str> {
+        let mut params = first_line.split_whitespace();
+        let method = params.next();
+        let path = params.next();
+
+        match (method, path) {
+            (Some("GET"), Some(path)) => {
+                println!("path: {}", path);
+
+                if let Some(code) = PATH_REGEX.captures(path) {
+                    let code = code.name("code").unwrap().as_str();
+                    Ok(code)
+                } else {
+                    Err("failed capture auth_code")
+                }
+            }
+            _ => Err("Unknown Http Method."),
+        }
     }
 }
 
@@ -21,9 +41,8 @@ impl AuthCodeServer {
         AuthCodeServer { port }
     }
 
-    pub fn receive_auth_code(self) -> Result<String, ()> {
+    pub fn receive_auth_code(self) -> Result<String, String> {
         let server = TcpListener::bind(format!("127.0.0.1:{}", self.port)).unwrap();
-        let mut auth_code_opt: Option<String> = None;
         if let Some(stream) = server.incoming().next() {
             match stream {
                 Ok(stream) => {
@@ -33,47 +52,25 @@ impl AuthCodeServer {
                         error!("{}", error);
                     }
 
-                    // スペースで分割
-                    let mut params = first_line.split_whitespace();
-                    let method = params.next();
-                    let path = params.next();
-                    let auth_code_result = match (method, path) {
-                        (Some("GET"), Some(path)) => {
+                    match path_util::split_auth_code(first_line.as_str()) {
+                        Ok(code) => {
                             let stream = stream.get_mut();
-                            println!("path: {}", path);
+                            writeln!(stream, "HTTP/1.1 200 OK").unwrap();
+                            writeln!(stream, "Content-Type: text/plain; charset=UTF-8").unwrap();
+                            writeln!(stream, "auth_code={}", code.to_string()).unwrap();
 
-                            if let Some(code) = path_util::PATH_REGEX.captures(path) {
-                                let code = code.name("code").unwrap().as_str();
-
-                                // ブラウザに空レスポンス
-                                writeln!(stream, "HTTP/1.1 200 OK").unwrap();
-                                writeln!(stream, "Content-Type: text/plain; charset=UTF-8")
-                                    .unwrap();
-                                writeln!(stream, "{}", code).unwrap();
-                                Ok(code)
-                            } else {
-                                Err("failed capture auth_code")
-                            }
-                        }
-                        _ => Err("unknown Method"),
-                    };
-                    match auth_code_result {
-                        Ok(code) => auth_code_opt = Some(code.to_string()),
-                        Err(str) => error!("{}", str),
+                            debug!("get auth code: {}", code);
+                            return Ok(code.to_string());
+                        },
+                        Err(err) => error!("{}", err),
                     }
                 }
-                Err(_) => {
-                    error!("Callback Server error");
+                Err(err) => {
+                    error!("Server Received Unexpected Response. {}", err);
                 }
             }
         }
-        match auth_code_opt {
-            Some(code) => {
-                debug!("get auth code: {}", code);
-                Ok(code)
-            },
-            None => Err(()),
-        }
+        Err("Can not receive auth_code".to_string())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use log::error;
 
 use crate::cli::AppError;
 
+mod authserver;
 mod cli;
 mod logger;
 mod oauth2;

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -2,32 +2,23 @@ use rand::distributions::Alphanumeric;
 use std::fmt::Display;
 use std::fs;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
-use std::net::TcpListener;
+use std::io::BufReader;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 use rand::Rng;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::authserver::AuthCodeServer;
 use crate::oauth2::GrantType::{AuthorizationCode, ClientCredentials, Password};
 use crate::profile::InvalidConfig;
 use crate::version;
 use reqwest::header::USER_AGENT;
 use std::io::Write;
-
-mod path_util {
-    use clap::lazy_static::lazy_static;
-    use regex::Regex;
-
-    lazy_static! {
-        pub static ref PATH_REGEX: Regex = Regex::new(".*?code=(?P<code>.+)&").unwrap();
-    }
-}
 
 pub struct OAuth2Config {
     pub auth_server_auth_endpoint: Option<String>,
@@ -218,19 +209,6 @@ mod test {
     use std::{thread, time::Duration};
 
     use super::*;
-
-    #[test]
-    fn test_regex_path() {
-        match path_util::PATH_REGEX
-            .captures("?hogehoge=fugafuga&code=ZZZZ-XXXX-CCCC&state=hogehoge")
-        {
-            Some(path) => {
-                let code = path.name("code").unwrap().as_str();
-                assert_eq!(code, "ZZZZ-XXXX-CCCC")
-            }
-            None => panic!("test failed"),
-        }
-    }
 
     #[test]
     fn test_cache_path() {
@@ -446,57 +424,11 @@ impl GrantType {
 
                 webbrowser::open(url).unwrap();
 
-                // 3. URL から認可コードを取得する
-                let mut auth_code = String::new();
-
+                // 3. 認可コードを取得する
                 // 指定ポートで Callback 待ち構える
                 // TODO: port を可変にする
-                let server = TcpListener::bind("127.0.0.1:8080").unwrap();
-                for stream in server.incoming() {
-                    match stream {
-                        Ok(stream) => {
-                            let mut stream = io::BufReader::new(stream);
-                            let mut first_line = String::new();
-                            if let Err(error) = stream.read_line(&mut first_line) {
-                                error!("{}", error);
-                                break;
-                            }
-
-                            // スペースで分割
-                            let mut params = first_line.split_whitespace();
-                            let method = params.next();
-                            let path = params.next();
-                            let auth_code_result = match (method, path) {
-                                (Some("GET"), Some(path)) => {
-                                    let stream = stream.get_mut();
-                                    println!("path: {}", path);
-
-                                    if let Some(code) = path_util::PATH_REGEX.captures(path) {
-                                        let code = code.name("code").unwrap().as_str();
-
-                                        // ブラウザに空レスポンス
-                                        writeln!(stream, "HTTP/1.1 200 OK").unwrap();
-                                        writeln!(stream, "Content-Type: text/plain; charset=UTF-8")
-                                            .unwrap();
-                                        writeln!(stream, "{}", code).unwrap();
-                                        Ok(code)
-                                    } else {
-                                        Err("failed capture auth_code")
-                                    }
-                                }
-                                _ => Err("unknown Method"),
-                            };
-                            match auth_code_result {
-                                Ok(code) => auth_code = code.to_string(),
-                                Err(str) => error!("{}", str),
-                            }
-                            break;
-                        }
-                        Err(_) => {
-                            error!("Callback Server error");
-                        }
-                    }
-                }
+                let server = AuthCodeServer::new(8080);
+                let auth_code = server.receive_auth_code().unwrap();
 
                 // 4. 認可コードをトークンエンドポイントへ POST. AccessToken を取得
                 http.post(config.auth_server_token_endpoint()?)


### PR DESCRIPTION
# 内容

- feat: code=XXX を抽出できる正規表現パターンを追加
- feat: 標準入力を待ち構えていたコードを廃止、サーバーで抽出した認可コードを処理に利用するように変更
- feat: 追加した正規表現パターンのテストコードを追加

### Changed

- Add Local HTTP Server for parsing Authorization Code
- Fix redundant test fixture code. `long_verifier_ng` in oauth.rs 