### PR TITLE
ヘッダ箇所と本文の間に空の改行が必要だったため修正

### DIFF
--- a/src/authserver.rs
+++ b/src/authserver.rs
@@ -1,6 +1,6 @@
-use log::{error, debug};
-use std::io::{self, BufRead};
+use log::{debug, error};
 use std::io::Write;
+use std::io::{self, BufRead};
 use std::net::TcpListener;
 
 mod path_util {
@@ -56,12 +56,13 @@ impl AuthCodeServer {
                         Ok(code) => {
                             let stream = stream.get_mut();
                             writeln!(stream, "HTTP/1.1 200 OK").unwrap();
-                            writeln!(stream, "Content-Type: text/plain; charset=UTF-8").unwrap();
+                            writeln!(stream, "Content-Type: text/plain; charset=UTF-8\r\n")
+                                .unwrap();
                             writeln!(stream, "auth_code={}", code).unwrap();
 
                             debug!("get auth code: {}", code);
                             return Ok(code.to_string());
-                        },
+                        }
                         Err(err) => error!("{}", err),
                     }
                 }


### PR DESCRIPTION
# 概要

取得した認証コードを Local Server で Response で表示するように修正。正常にHTTP Reponseになっていなかったため修正

# 修正内容

- Content−Type のヘッダ箇所と本文の間に空の改行が必要だったため修正