### PR TITLE
バグ修正・セキュリティ強化: 認証ヘッダー・カスタムヘッダー・OAuthコールバック・stateエントロピー・無限ループ対策

### DIFF
--- a/src/authserver.rs
+++ b/src/authserver.rs
@@ -8,7 +8,7 @@ mod path_util {
     use regex::Regex;
 
     lazy_static! {
-        pub static ref PATH_REGEX: Regex = Regex::new(".*?code=(?P<code>.+)&").unwrap();
+        pub static ref PATH_REGEX: Regex = Regex::new(".*?code=(?P<code>[^& ]+)").unwrap();
     }
 
     pub fn split_auth_code(first_line: &str) -> Result<&str, &str> {
@@ -89,6 +89,17 @@ mod test {
                 assert_eq!(code, "ZZZZ-XXXX-CCCC")
             }
             None => panic!("test failed"),
+        }
+    }
+
+    #[test]
+    fn test_regex_path_code_at_end() {
+        match path_util::PATH_REGEX.captures("?state=hogehoge&code=ZZZZ-XXXX-CCCC") {
+            Some(path) => {
+                let code = path.name("code").unwrap().as_str();
+                assert_eq!(code, "ZZZZ-XXXX-CCCC")
+            }
+            None => panic!("test failed: code at end of query string not matched"),
         }
     }
 }

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -495,11 +495,9 @@ impl PkceMethod {
     }
 }
 
-// Generate Random State String
+// Generate Random State String (128-bit entropy, RFC 6749 compliant)
 fn random() -> String {
     let mut rng = rand::thread_rng();
-    let val: i32 = rng.gen();
-
-    // TODO: なんかアレなのでどうにかする
-    base64::encode(&val.to_be_bytes())
+    let val: [u8; 16] = rng.gen();
+    base64::encode(&val)
 }

--- a/src/request/dispatcher.rs
+++ b/src/request/dispatcher.rs
@@ -13,6 +13,8 @@ pub struct Dispatcher {
 
 impl Dispatcher {
     pub async fn send(&self, opts: &Opts, oauth2: &OAuth2Config) -> Result<Response, RequestError> {
+        const MAX_RETRIES: u8 = 2;
+        let mut retries = 0u8;
         loop {
             let mut token = match AccessToken::load_cache(&opts.profile) {
                 Some(t) => t,
@@ -49,6 +51,10 @@ impl Dispatcher {
                     match res {
                         Err(e) if e.status() == Some(StatusCode::UNAUTHORIZED) => {
                             AccessToken::remove_cache(&opts.profile);
+                            retries += 1;
+                            if retries >= MAX_RETRIES {
+                                return Err(RequestError::Http(e));
+                            }
                         }
                         Err(e) => return Err(RequestError::Http(e)),
                         Ok(ok) => return Ok(Response::Dispatched(ok)),

--- a/src/request/modifier/auth_header.rs
+++ b/src/request/modifier/auth_header.rs
@@ -44,7 +44,7 @@ fn split_custom_header<'a>(
     template: &'a str,
     access_token: &'a str,
 ) -> Result<(&'a str, String), AccessTokenError> {
-    let split: Vec<&str> = template.split('=').collect();
+    let split: Vec<&str> = template.splitn(2, '=').collect();
     if split.len() != 2 {
         debug!("Failed parse custom_header_template, {}", template);
         Err(AccessTokenError::InvalidConfig(
@@ -55,10 +55,7 @@ fn split_custom_header<'a>(
             "can't find '$token' placeholder".to_string(),
         ))
     } else {
-        let value = split[1]
-            .trim()
-            .to_lowercase()
-            .replace("$token", access_token);
+        let value = split[1].trim().replace("$token", access_token);
         Ok((split[0], value))
     }
 }

--- a/src/request/modifier/custom_headers.rs
+++ b/src/request/modifier/custom_headers.rs
@@ -19,7 +19,7 @@ impl RequestModifier for CustomHeaders {
     ) -> Result<RequestBuilder, RequestError> {
         let mut headers = Headers::with_capacity(opts.header.len());
         for h in opts.header.clone() {
-            let kv = h.split(',').collect::<Vec<_>>();
+            let kv = h.splitn(2, ':').collect::<Vec<_>>();
             if kv.len() == 2 {
                 if let (Some(k), Some(v)) = (kv.get(0), kv.get(1)) {
                     headers.add((*k).to_string(), (*v).to_string());


### PR DESCRIPTION
- auth_header.rs: split('=') → splitn(2,'=') でトークン値内の'='を正しく処理
- auth_header.rs: to_lowercase() をプレースホルダーチェックのみに限定しトークン値の破壊を修正
- custom_headers.rs: -Hオプションの区切り文字をカンマからコロン(splitn(2,':'))に修正
- authserver.rs: OAuthコールバック正規表現を `[^& ]+` に変更し末尾パラメータを正しく取得
- authserver.rs: codeが末尾クエリパラメータの場合のテストケースを追加
- oauth2.rs: stateパラメータを32bitから128bit(16バイト)に強化しCSRF耐性を向上
- dispatcher.rs: 401時の無限リトライループに最大2回の上限を追加

https://claude.ai/code/session_017CX1Vj9kBhf4ioXX4JqFBZ